### PR TITLE
Mount extra classpath dependencies in /app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/tjheslin1/patterdale.svg?maxAge=604800)](https://hub.docker.com/r/tjheslin1/patterdale/)
 
-`docker run -d -p 7000:7000 -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:0.14.0`
+`docker run -d -p 7000:7000 -v /your/jdbc/driver.jar:/app/driver.jar -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:0.14.0`
 
 If a `logback.xml` file is included in the directory passed into the /config container volume, this will configure your logging.
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.5.v20170502'
     compile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.5.v20170502'
 
-    compile files('./repo/ojdbc7.jar')
+    shadow files('./repo/ojdbc7.jar')
     compile 'com.zaxxer:HikariCP:2.7.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
@@ -46,6 +46,10 @@ dependencies {
     testCompile "org.mockito:mockito-core:2.2.9"
     testCompile 'io.github.tjheslin1:Westie:1.4.2'
     testCompile group: 'commons-io', name: 'commons-io', version: '2.5'
+}
+
+tasks.withType(AbstractCompile) {
+    classpath += configurations.shadow
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,15 @@ dependencies {
     compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.5.v20170502'
     compile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.5.v20170502'
 
-    shadow files('./repo/ojdbc7.jar')
+    if (project.hasProperty('bundleOjdbc')) {
+        if (bundleOjdbc == "yes") {
+            compile files('./repo/ojdbc7.jar')
+            println("Including odjdbc7.jar")
+        }
+    } else {
+        shadow files('./repo/ojdbc7.jar')
+        println("Ignoring odjdbc7.jar")
+    }
     compile 'com.zaxxer:HikariCP:2.7.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 The example `docker run` commands includes two volume mounts:
 
-`docker run -d -p 7000:7000 -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:0.14.0`
+`docker run -d -p 7000:7000 -v /your/jdbc/driver.jar:/app/driver.jar -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:0.14.0`
 
 If a `logback.xml` file is included in the directory passed into the `/config` container volume, this will configure your logging.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ docker run -d -p 8082:8080 -p 1523:1521 sath89/oracle-12c
 
 ```
 docker build -t tjheslin1/patterdale:DEV .
-docker run --name patterdale-test -d -p 7001:7001 -v ~/Patterdale-jvm/src/main/resources/:/config -v ~/Patterdale-jvm/src/main/resources/:/passwords tjheslin1/patterdale:DEV
+docker run --name patterdale-test -d -p 7001:7001 -v ~/Patterdale-jvm/repo/ojdbc7.jar:/app/driver.jar -v ~/Patterdale-jvm/src/main/resources/:/config -v ~/Patterdale-jvm/src/main/resources/:/passwords tjheslin1/patterdale:DEV
 
 docker logs -f ${container_id}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ docker run -d -p 8082:8080 -p 1523:1521 sath89/oracle-12c
 
 ```
 docker build -t tjheslin1/patterdale:DEV .
-docker run --name patterdale-test -d -p 7001:7001 -v ~/Patterdale/repo/ojdbc7.jar:/app/driver.jar -v ~/Patterdale/src/test/resources/:/config -v ~/Patterdale/src/test/resources/:/passwords tjheslin1/patterdale:DEV
+docker run --name patterdale-test -d -p 7001:7001 -v ~/Patterdale/repo/ojdbc7.jar:/app/ojdbc7.jar -v ~/Patterdale/src/test/resources/:/config -v ~/Patterdale/src/test/resources/:/passwords tjheslin1/patterdale:DEV
 
 docker logs -f ${container_id}
 ```


### PR DESCRIPTION
Rather than bundling e.g. JDBC drivers in the application.

This fixes #3 and allows for JDBC drivers other than Oracle.