### PR TITLE
Add default metricLabels per database

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Prometheus Oracle database exporter. Runs provided queries.
 
-`docker run -d -p 7000:7000 -v /your/jdbc/odjbc7.jar:/app/odjbc7.jar -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:1.1.2`
+`docker run -d -p 7000:7000 -v /your/jdbc/odjbc7.jar:/app/odjbc7.jar -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:1.2.0`
 
 If a `logback.xml` file is included in the directory passed into the `/config` container volume, this will override your logging configuration.
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 group 'io.github.tjheslin1'
-version '1.1.2'
+version '1.2.0'
 
 apply plugin: 'java'
 apply plugin: 'com.github.johnrengelman.shadow'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 The example `docker run` command from the README includes two volume mounts:
 
-`docker run -d -p 7000:7000 -v /your/jdbc/ojdbc8.jar:/app/ojdbc8.jar -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:1.1.2`
+`docker run -d -p 7000:7000 -v /your/jdbc/ojdbc8.jar:/app/ojdbc8.jar -v /your/config/directory:/config -v /your/secrets/directory:/passwords tjheslin1/patterdale:1.2.0`
 
 ## System properties
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ The app will wait for this time for each scrape, once it has passed once it will
 
 `databases` is a list of the databases the application will connect to.
 Each database definition references probes defined in the `probes` list below, to be executed against that database.
+The optional `metricLabels` field defines a list of metric label and value key-pairs that will be added to every probe for that database.
 
 Note: The metric label of `database=${databaseName}` will be automatically appended to all _metricLabels_.
 
@@ -59,6 +60,8 @@ databases:
     jdbcUrl: jdbc:oracle:thin:@localhost:1522:xe
     probes:
       - healthCheck
+    metricLabels:
+      label: value
   - name: alicesDatabase
     user: system
     jdbcUrl: jdbc:oracle:thin:@localhost:1523:xe

--- a/src/main/java/io/github/tjheslin1/patterdale/Patterdale.java
+++ b/src/main/java/io/github/tjheslin1/patterdale/Patterdale.java
@@ -138,7 +138,7 @@ public class Patterdale {
 
     private Stream<OracleSQLProbe> createProbes(DatabaseDefinition databaseDefinition) {
         return Arrays.stream(databaseDefinition.probes)
-                .map(probeName -> typeToProbeMapper.createProbe(databaseDefinition.name, connectionPools.get(databaseDefinition.name), probesByName.get(probeName), runtimeParameters));
+                .map(probeName -> typeToProbeMapper.createProbe(databaseDefinition, connectionPools.get(databaseDefinition.name), probesByName.get(probeName), runtimeParameters));
     }
 
 }

--- a/src/main/java/io/github/tjheslin1/patterdale/config/ConfigUnmarshaller.java
+++ b/src/main/java/io/github/tjheslin1/patterdale/config/ConfigUnmarshaller.java
@@ -44,11 +44,9 @@ public class ConfigUnmarshaller {
      * @return an in memory representation of the config.
      */
     public PatterdaleConfig parseConfig(File configFile) {
-        PatterdaleConfig config;
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         try {
-            config = mapper.readValue(configFile, PatterdaleConfig.class);
-            return config;
+            return mapper.readValue(configFile, PatterdaleConfig.class);
         } catch (IOException e) {
             logger.error(format("Failed to parse provided file '%s'.", configFile.getName()), e);
             throw new IllegalArgumentException(format("Error occurred reading config file '%s'.", configFile.getName()), e);

--- a/src/main/java/io/github/tjheslin1/patterdale/metrics/probe/DatabaseDefinition.java
+++ b/src/main/java/io/github/tjheslin1/patterdale/metrics/probe/DatabaseDefinition.java
@@ -20,6 +20,7 @@ package io.github.tjheslin1.patterdale.metrics.probe;
 import io.github.tjheslin1.patterdale.ValueType;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The in-memory representation of databases list in 'patterdale.yml', passed in on app start-up.
@@ -29,6 +30,7 @@ public class DatabaseDefinition extends ValueType {
     public String user;
     public String jdbcUrl;
     public String[] probes;
+    public Map<String, String> metricLabels;
 
     // test use only
     public static DatabaseDefinition databaseDefinition(String name, String user, String jdbcUrl, List<String> probes) {
@@ -37,6 +39,14 @@ public class DatabaseDefinition extends ValueType {
         databaseDefinition.user = user;
         databaseDefinition.jdbcUrl = jdbcUrl;
         databaseDefinition.probes = probes.toArray(new String[probes.size()]);
+
+        return databaseDefinition;
+    }
+
+    // test use only
+    public static DatabaseDefinition databaseDefinition(String name, String user, String jdbcUrl, List<String> probes, Map<String, String> metricLabels) {
+        final DatabaseDefinition databaseDefinition = databaseDefinition(name, user, jdbcUrl, probes);
+        databaseDefinition.metricLabels = metricLabels;
 
         return databaseDefinition;
     }

--- a/src/main/java/io/github/tjheslin1/patterdale/metrics/probe/Probe.java
+++ b/src/main/java/io/github/tjheslin1/patterdale/metrics/probe/Probe.java
@@ -19,8 +19,6 @@ package io.github.tjheslin1.patterdale.metrics.probe;
 
 import io.github.tjheslin1.patterdale.ValueType;
 
-import static java.lang.String.format;
-
 /**
  * The in-memory representation of probes list in 'patterdale.yml', passed in on app start-up.
  */
@@ -44,8 +42,20 @@ public class Probe extends ValueType {
         return probe;
     }
 
-    public Probe dbLabelled(String databaseName) {
-        return probe(this.name, this.query, this.type, this.metricName, format("database=\"%s\",", databaseName) + this.metricLabels);
+    public Probe dbLabelled(DatabaseDefinition databaseDefinition) {
+        return probe(this.name, this.query, this.type, this.metricName, getMetricLabels(databaseDefinition));
+    }
+
+    private String getMetricLabels(DatabaseDefinition databaseDefinition) {
+        final StringBuilder builder = new StringBuilder("database=\"").append(databaseDefinition.name).append("\",");
+
+        if(databaseDefinition.metricLabels != null) {
+            databaseDefinition.metricLabels.forEach((label, value) -> builder.append(label).append("=\"").append(value).append("\","));
+        }
+
+        builder.append(this.metricLabels);
+
+        return builder.toString();
     }
 
     public String query() {

--- a/src/main/java/io/github/tjheslin1/patterdale/metrics/probe/TypeToProbeMapper.java
+++ b/src/main/java/io/github/tjheslin1/patterdale/metrics/probe/TypeToProbeMapper.java
@@ -36,8 +36,8 @@ public class TypeToProbeMapper {
         this.logger = logger;
     }
 
-    public OracleSQLProbe createProbe(String databaseName, Future<DBConnectionPool> dbConnectionPool, Probe probe, RuntimeParameters runtimeParameters) {
-        Probe dbLabelledProbe = probe.dbLabelled(databaseName);
+    public OracleSQLProbe createProbe(DatabaseDefinition databaseDefinition, Future<DBConnectionPool> dbConnectionPool, Probe probe, RuntimeParameters runtimeParameters) {
+        Probe dbLabelledProbe = probe.dbLabelled(databaseDefinition);
         switch (dbLabelledProbe.type) {
             case EXISTS: {
                 return new ExistsOracleSQLProbe(dbLabelledProbe, dbConnectionPool, runtimeParameters, logger);

--- a/src/test/java/functional/PatterdaleTest.java
+++ b/src/test/java/functional/PatterdaleTest.java
@@ -38,7 +38,7 @@ public class PatterdaleTest implements WithAssertions {
 
         String responseBody = responseBody(response);
         assertThat(responseBody).matches(Pattern.compile(
-                "database_up\\{database=\"bobsDatabase\",query=\"SELECT 1 FROM DUAL\"} 1.0\n" +
+                "database_up\\{database=\"bobsDatabase\",label=\"value\",query=\"SELECT 1 FROM DUAL\"} 1.0\n" +
                         "database_up\\{database=\"alicesDatabase\",query=\"SELECT 1 FROM DUAL\"} 1.0\n" +
                         ".*"
                 , Pattern.DOTALL)

--- a/src/test/java/io/github/tjheslin1/patterdale/config/ConfigUnmarshallerTest.java
+++ b/src/test/java/io/github/tjheslin1/patterdale/config/ConfigUnmarshallerTest.java
@@ -20,6 +20,7 @@ import static io.github.tjheslin1.patterdale.metrics.probe.Probe.probe;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
 public class ConfigUnmarshallerTest implements WithAssertions, WithMockito {
 
@@ -66,7 +67,7 @@ public class ConfigUnmarshallerTest implements WithAssertions, WithMockito {
         expectedConfig.httpPort = 7001;
         expectedConfig.cacheDuration = 60;
         expectedConfig.databases = new DatabaseDefinition[]{
-                databaseDefinition(NAME, USER, JDBC_URL, singletonList("healthCheck")),
+                databaseDefinition(NAME, USER, JDBC_URL, singletonList("healthCheck"), singletonMap("label", "value")),
                 databaseDefinition(NAME_2, USER, JDBC_URL_2, asList("healthCheck", "slowestQueries"))
         };
 

--- a/src/test/java/io/github/tjheslin1/patterdale/metrics/probe/ProbeTest.java
+++ b/src/test/java/io/github/tjheslin1/patterdale/metrics/probe/ProbeTest.java
@@ -3,6 +3,12 @@ package io.github.tjheslin1.patterdale.metrics.probe;
 import org.assertj.core.api.WithAssertions;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.github.tjheslin1.patterdale.metrics.probe.DatabaseDefinition.databaseDefinition;
+import static java.util.Collections.emptyList;
+
 public class ProbeTest implements WithAssertions {
 
     @Test
@@ -10,5 +16,17 @@ public class ProbeTest implements WithAssertions {
         Probe probe = Probe.probe("name", "SELECT 1 FROM DUAL ; ", "", "", "");
 
         assertThat(probe.query()).isEqualTo("SELECT 1 FROM DUAL");
+    }
+
+    @Test
+    public void dbLabelledPassesMetricLabelsFromDatabaseDefinitionToProbe() {
+        final Probe probe = Probe.probe("name", "SELECT 1 FROM DUAL ; ", "", "", "probeLabel=\"probeValue\"");
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("label1", "value1");
+        labels.put("label2", "value2");
+
+        final Probe got = probe.dbLabelled(databaseDefinition("db", "user", "url", emptyList(), labels));
+
+        assertThat(got.metricLabels).isEqualTo("database=\"db\",label1=\"value1\",label2=\"value2\",probeLabel=\"probeValue\"");
     }
 }

--- a/src/test/java/io/github/tjheslin1/patterdale/metrics/probe/TypeToProbeMapperTest.java
+++ b/src/test/java/io/github/tjheslin1/patterdale/metrics/probe/TypeToProbeMapperTest.java
@@ -10,10 +10,13 @@ import testutil.WithMockito;
 import java.util.concurrent.Future;
 
 import static io.github.tjheslin1.patterdale.metrics.probe.Probe.probe;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 public class TypeToProbeMapperTest implements WithAssertions, WithMockito {
 
     private static final Probe EXIST_PROBE_DEFINITION = probe("name", "SQL", "exists", "metricName", "metricLabels");
+    private static final DatabaseDefinition DATABASE_DEFINITION = DatabaseDefinition.databaseDefinition("dbName", "user", "url", emptyList(), emptyMap());
 
     private final Future<DBConnectionPool> dbConnectionPool = mock(Future.class);
     private final RuntimeParameters runtimeParameters = mock(RuntimeParameters.class);
@@ -21,13 +24,13 @@ public class TypeToProbeMapperTest implements WithAssertions, WithMockito {
 
     @Test
     public void mapsKnownTypeToSqlProbeClass() throws Exception {
-        OracleSQLProbe oracleSQLProbe = new TypeToProbeMapper(logger).createProbe("dbName", dbConnectionPool, EXIST_PROBE_DEFINITION, runtimeParameters);
+        OracleSQLProbe oracleSQLProbe = new TypeToProbeMapper(logger).createProbe(DATABASE_DEFINITION, dbConnectionPool, EXIST_PROBE_DEFINITION, runtimeParameters);
 
         assertThat(oracleSQLProbe).isExactlyInstanceOf(ExistsOracleSQLProbe.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void blowsUpForUnknownTypeParameter() throws Exception {
-        new TypeToProbeMapper(logger).createProbe("dbName", dbConnectionPool, probe("name", "", "none", "", ""), runtimeParameters);
+        new TypeToProbeMapper(logger).createProbe(DATABASE_DEFINITION, dbConnectionPool, probe("name", "", "none", "", ""), runtimeParameters);
     }
 }

--- a/src/test/java/resiliency/ResiliencyTest.java
+++ b/src/test/java/resiliency/ResiliencyTest.java
@@ -27,7 +27,7 @@ public class ResiliencyTest implements WithAssertions {
 
         String responseBody = responseBody(response);
         assertThat(responseBody).matches(Pattern.compile(
-                "database_up\\{database=\"bobsDatabase\",query=\"SELECT 1 FROM DUAL\"} -1.0\n" +
+                "database_up\\{database=\"bobsDatabase\",label=\"value\",query=\"SELECT 1 FROM DUAL\"} -1.0\n" +
                         "database_up\\{database=\"alicesDatabase\",query=\"SELECT 1 FROM DUAL\"} -1.0\n" +
                         "slowest_queries\\{.*} -1.0\n" +
                         ".*"

--- a/src/test/resources/patterdale-h2.yml
+++ b/src/test/resources/patterdale-h2.yml
@@ -7,6 +7,8 @@ databases:
     jdbcUrl: jdbc:h2:mem:test;MODE=Oracle
     probes:
       - healthCheck
+    metricLabels:
+      label: value
   - name: alicesDatabase
     user: user
     jdbcUrl: jdbc:h2:mem:test;MODE=Oracle

--- a/src/test/resources/patterdale.yml
+++ b/src/test/resources/patterdale.yml
@@ -7,6 +7,8 @@ databases:
     jdbcUrl: jdbc:oracle:thin:@localhost:1522:xe
     probes:
       - healthCheck
+    metricLabels:
+      label: value
   - name: alicesDatabase
     user: system
     jdbcUrl: jdbc:oracle:thin:@localhost:1523:xe


### PR DESCRIPTION
Patterdale can currently add default metric labels as part of a probe definition. However, it would be useful to be able to add a default metric label for any probe configured for a database.

Any label added for the database definition should be added to each of the probe metrics for that database.