### PR TITLE
Changed line breaks of output to CR to work on all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 install: true
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/src/main/java/io/github/tjheslin1/patterdale/http/MetricsServlet.java
+++ b/src/main/java/io/github/tjheslin1/patterdale/http/MetricsServlet.java
@@ -56,7 +56,7 @@ public class MetricsServlet extends HttpServlet {
         formatProbeResults(probeResults)
                 .forEach(formattedProbeResult -> {
                     try {
-                        resp.getWriter().println(formattedProbeResult);
+                        resp.getWriter().print(formattedProbeResult + "\n");
                     } catch (IOException e) {
                         logger.error("IO error occurred writing to /metrics page.", e);
                     }

--- a/src/test/java/io/github/tjheslin1/patterdale/http/MetricsServletTest.java
+++ b/src/test/java/io/github/tjheslin1/patterdale/http/MetricsServletTest.java
@@ -40,9 +40,9 @@ public class MetricsServletTest implements WithAssertions, WithMockito {
         metricsServlet.doGet(request, response);
 
         verify(metricsUseCase).scrapeMetrics();
-        verify(printerWriter).println("database_up{key=\"value\"} 1.0");
-        verify(printerWriter).println("database_other{key=\"something\"} 1.0");
-        verify(printerWriter).println("database_list{key=\"somethingElse\",result=\"example SQL\"} 4.5");
+        verify(printerWriter).print("database_up{key=\"value\"} 1.0\n");
+        verify(printerWriter).print("database_other{key=\"something\"} 1.0\n");
+        verify(printerWriter).print("database_list{key=\"somethingElse\",result=\"example SQL\"} 4.5\n");
     }
 
     @Test
@@ -53,8 +53,8 @@ public class MetricsServletTest implements WithAssertions, WithMockito {
         metricsServlet.doGet(request, response);
 
         verify(metricsUseCase).scrapeMetrics();
-        verify(printerWriter).println("database_up{key=\"value\"} 1.0");
-        verify(printerWriter).println("database_other{key=\"something\"} 0.0");
+        verify(printerWriter).print("database_up{key=\"value\"} 1.0\n");
+        verify(printerWriter).print("database_other{key=\"something\"} 0.0\n");
     }
 
     @Test


### PR DESCRIPTION
Prometheus is not able to parse output of MetricsServlet when running Patterdale on windows.